### PR TITLE
Add support for ATSAMD21E15A

### DIFF
--- a/src/Devices.h
+++ b/src/Devices.h
@@ -30,7 +30,7 @@
 #ifndef _DEVICES_H_
 #define _DEVICES_H_
 
-#define ATSAM_APPLET_MAX_SIZE                (0x1000)
+#define ATSAM_APPLET_MAX_SIZE                (0x0400)
 
 #define ATSAMD_CHIPID_MASK                   (0xFFFF00FFul)  // mask for DIE & REV bitfields removal in Samba::chipId()
 #define ATSAMD_BOOTLOADER_SIZE               (0x00002000ul)  // 8192 bytes
@@ -69,5 +69,15 @@
 #define ATSAMD21E18A_STACK_ADDR              (0x20008000ul)
 #define ATSAMD21E18A_NVMCTRL_BASE            (0x41004000ul)
 
+#define ATSAMD21E15A_NAME                    "ATSAMD21E15A"
+#define ATSAMD21E15A_CHIPID                  (0x1001000dul)  // DIE & REV bitfields masked in Samba::chipId()
+#define ATSAMD21E15A_FLASH_BASE              (0x00000000ul + ATSAMD_BOOTLOADER_SIZE)
+#define ATSAMD21E15A_FLASH_PAGE_SIZE         (64ul)
+#define ATSAMD21E15A_FLASH_PAGES             (512ul)
+#define ATSAMD21E15A_FLASH_PLANES            (1ul)
+#define ATSAMD21E15A_FLASH_LOCK_REGIONS      (16ul)
+#define ATSAMD21E15A_BUFFER_ADDR             (0x20000800ul)
+#define ATSAMD21E15A_STACK_ADDR              (0x20001000ul)
+#define ATSAMD21E15A_NVMCTRL_BASE            (0x41004000ul)
 
 #endif // _DEVICES_H_

--- a/src/FlashFactory.cpp
+++ b/src/FlashFactory.cpp
@@ -68,6 +68,12 @@ FlashFactory::create(Samba& samba, uint32_t chipId)
                               ATSAMD21E18A_FLASH_PLANES, ATSAMD21E18A_FLASH_LOCK_REGIONS,
                               ATSAMD21E18A_BUFFER_ADDR, ATSAMD21E18A_STACK_ADDR, ATSAMD21E18A_NVMCTRL_BASE, /*canBrownout*/true ) ;
         break ;
+        
+    case ATSAMD21E15A_CHIPID:
+        flash = new NvmFlash( samba, ATSAMD21E15A_NAME, ATSAMD21E15A_FLASH_BASE, ATSAMD21E15A_FLASH_PAGES, ATSAMD21E15A_FLASH_PAGE_SIZE,
+                              ATSAMD21E15A_FLASH_PLANES, ATSAMD21E15A_FLASH_LOCK_REGIONS,
+                              ATSAMD21E15A_BUFFER_ADDR, ATSAMD21E15A_STACK_ADDR, ATSAMD21E15A_NVMCTRL_BASE, /*canBrownout*/true ) ;
+        break ;
 
     //
     // SAM7SE
@@ -242,4 +248,3 @@ FlashFactory::create(Samba& samba, uint32_t chipId)
 
     return Flash::Ptr(flash);
 }
-

--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -146,7 +146,7 @@ Samba::init()
     }
     // Check for supported M0+ processor
     // NOTE: 0x1001000a is a ATSAMD21E18A
-	else if (cid == 0x10010000 || cid == 0x10010100 || cid == 0x10010005 || cid == 0x1001000a)
+	else if (cid == 0x10010000 || cid == 0x10010100 || cid == 0x10010005 || cid == 0x1001000a || cid == 0x1001000d)
     {
         return true;
     }
@@ -611,6 +611,8 @@ Samba::reset(void)
     {
     case ATSAMD21J18A_CHIPID:
     case ATSAMD21G18A_CHIPID:
+    case ATSAMD21E18A_CHIPID:
+    case ATSAMD21E15A_CHIPID:
         // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0484c/index.html
         writeWord(0xE000ED0C, 0x05FA0004);
         break;


### PR DESCRIPTION
In order to get BOSSA to work correctly with the SAMD21E15A, which only has 4 kB of SRAM (compared to the 32 kB SRAM available on the 18 variant), I had to modify ATSAM_APPLET_MAX_SIZE in Devices.h from 0x1000 to 0x0400. Looking over the file which generates the helper applet that is loaded in to SRAM, it appears this is still plenty of room for it to operate, but admittedly I'm not sure of all of the consequences of changing this parameter, so if you need to reject the pull request, just let me know what else I would need to do to ensure proper functioning of BOSSA.

If the pull request is accepted, I should be able to add support for the rest of the devices in the SAMD21 line easily enough.
